### PR TITLE
Frontend image broken issue

### DIFF
--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -39,7 +39,7 @@ function frontAssets($path) {
 }
 
 function webAssets($path) {
-	$asset = config('constant.ENVIRONMENT') == 'production' ? '' . $path : '' . $path;
+	$asset = config('constant.ENVIRONMENT') == 'production' ? 'private/public/' . $path : 'private/public/' . $path;
 	return asset($asset);
 }
 

--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -39,7 +39,7 @@ function frontAssets($path) {
 }
 
 function webAssets($path) {
-	$asset = config('constant.ENVIRONMENT') == 'production' ? 'private/public/' . $path : 'private/public/' . $path;
+	$asset = config('constant.ENVIRONMENT') == 'production' ? 'private/public/' . $path : 'public/' . $path;
 	return asset($asset);
 }
 


### PR DESCRIPTION
On the frontend view plan, images were not displaying for the category, subcategory, and meals sections.
To fix this, the image path was set in the helpers.php file.